### PR TITLE
[asm-cherry-pick] Multiple methods for initializing analysis values

### DIFF
--- a/src/main/java/scala/tools/asm/tree/analysis/Frame.java
+++ b/src/main/java/scala/tools/asm/tree/analysis/Frame.java
@@ -312,12 +312,12 @@ public class Frame<V extends Value> {
             var = ((VarInsnNode) insn).var;
             setLocal(var, value1);
             if (value1.getSize() == 2) {
-                setLocal(var + 1, interpreter.newValue(null));
+                setLocal(var + 1, interpreter.newEmptyValueAfterSize2Local(var + 1));
             }
             if (var > 0) {
                 Value local = getLocal(var - 1);
                 if (local != null && local.getSize() == 2) {
-                    setLocal(var - 1, interpreter.newValue(null));
+                    setLocal(var - 1, interpreter.newEmptyValueForPreviousSize2Local(var - 1));
                 }
             }
             break;

--- a/src/main/java/scala/tools/asm/tree/analysis/Interpreter.java
+++ b/src/main/java/scala/tools/asm/tree/analysis/Interpreter.java
@@ -33,6 +33,7 @@ import java.util.List;
 
 import scala.tools.asm.Type;
 import scala.tools.asm.tree.AbstractInsnNode;
+import scala.tools.asm.tree.TryCatchBlockNode;
 
 /**
  * A semantic bytecode interpreter. More precisely, this interpreter only
@@ -69,6 +70,55 @@ public abstract class Interpreter<V extends Value> {
      *         value must be equal to the size of the given type.
      */
     public abstract V newValue(Type type);
+
+    /**
+     * Called by the analyzer for initializing the return type value of a frame.
+     */
+    public V newReturnTypeValue(Type type) {
+        return newValue(type);
+    }
+
+    /**
+     * Called by the analyzer when initializing the value of a parameter in a frame.
+     */
+    public V newParameterValue(boolean isInstanceMethod, int local, Type type) {
+        return newValue(type);
+    }
+
+    /**
+     * Called by the analyzer when initializing a non-parameter local in a frame.
+     * This method has to return a size-1 value representing an empty slot.
+     */
+    public V newEmptyNonParameterLocalValue(int local) {
+        return newValue(null);
+    }
+
+    /**
+     * Called by the analyzer and the interpreter. When initializing or setting the value of a
+     * size-2 local, the value of the subsequent slot is reset using this method.
+     * This method has to return a size-1 value representing an empty slot.
+     */
+    public V newEmptyValueAfterSize2Local(int local) {
+        return newValue(null);
+    }
+
+    /**
+     * Called by the interpreter. When setting the value of a local variable, the interpreter checks
+     * whether the current value stored at the preceding index is of size-2. In this case, the
+     * preceding size-2 value is no longer valid and reset using this method.
+     * This method has to return a size-1 value representing an empty slot.
+     */
+    public V newEmptyValueForPreviousSize2Local(int local) {
+        return newValue(null);
+    }
+
+    /**
+     * Called by the analyzer when initializing the exception value on the call stack at the entry
+     * of an exception handler.
+     */
+    public V newExceptionValue(TryCatchBlockNode tryCatchBlockNode, Frame handlerFrame, Type exceptionType) {
+        return newValue(exceptionType);
+    }
 
     /**
      * Interprets a bytecode instruction without arguments. This method is


### PR DESCRIPTION
Introduces a number of methods that are called when initializing or
updating abstract values in an analyzer frame.

Before this commit, Analyzer.analyze and Frame.execute would always
call Interpreter.newValue for initializing or updating frame values.

Having multiple methods allows users to return more precise values
for the individual cases. For example, in a nullness analysis, the
initial value for the `this` parameter of an instance method can be
set to not-null.