### PR TITLE
Call interpreter.copyInstruction consistently for all copied values

### DIFF
--- a/src/main/java/scala/tools/asm/tree/analysis/Frame.java
+++ b/src/main/java/scala/tools/asm/tree/analysis/Frame.java
@@ -351,7 +351,7 @@ public class Frame<V extends Value> {
             if (value1.getSize() != 1) {
                 throw new AnalyzerException(insn, "Illegal use of DUP");
             }
-            push(value1);
+            push(interpreter.copyOperation(insn, value1));
             push(interpreter.copyOperation(insn, value1));
             break;
         case Opcodes.DUP_X1:
@@ -361,8 +361,8 @@ public class Frame<V extends Value> {
                 throw new AnalyzerException(insn, "Illegal use of DUP_X1");
             }
             push(interpreter.copyOperation(insn, value1));
-            push(value2);
-            push(value1);
+            push(interpreter.copyOperation(insn, value2));
+            push(interpreter.copyOperation(insn, value1));
             break;
         case Opcodes.DUP_X2:
             value1 = pop();
@@ -372,15 +372,15 @@ public class Frame<V extends Value> {
                     value3 = pop();
                     if (value3.getSize() == 1) {
                         push(interpreter.copyOperation(insn, value1));
-                        push(value3);
-                        push(value2);
-                        push(value1);
+                        push(interpreter.copyOperation(insn, value3));
+                        push(interpreter.copyOperation(insn, value2));
+                        push(interpreter.copyOperation(insn, value1));
                         break;
                     }
                 } else {
                     push(interpreter.copyOperation(insn, value1));
-                    push(value2);
-                    push(value1);
+                    push(interpreter.copyOperation(insn, value2));
+                    push(interpreter.copyOperation(insn, value1));
                     break;
                 }
             }
@@ -390,14 +390,14 @@ public class Frame<V extends Value> {
             if (value1.getSize() == 1) {
                 value2 = pop();
                 if (value2.getSize() == 1) {
-                    push(value2);
-                    push(value1);
+                    push(interpreter.copyOperation(insn, value2));
+                    push(interpreter.copyOperation(insn, value1));
                     push(interpreter.copyOperation(insn, value2));
                     push(interpreter.copyOperation(insn, value1));
                     break;
                 }
             } else {
-                push(value1);
+                push(interpreter.copyOperation(insn, value1));
                 push(interpreter.copyOperation(insn, value1));
                 break;
             }
@@ -411,9 +411,9 @@ public class Frame<V extends Value> {
                     if (value3.getSize() == 1) {
                         push(interpreter.copyOperation(insn, value2));
                         push(interpreter.copyOperation(insn, value1));
-                        push(value3);
-                        push(value2);
-                        push(value1);
+                        push(interpreter.copyOperation(insn, value3));
+                        push(interpreter.copyOperation(insn, value2));
+                        push(interpreter.copyOperation(insn, value1));
                         break;
                     }
                 }
@@ -421,8 +421,8 @@ public class Frame<V extends Value> {
                 value2 = pop();
                 if (value2.getSize() == 1) {
                     push(interpreter.copyOperation(insn, value1));
-                    push(value2);
-                    push(value1);
+                    push(interpreter.copyOperation(insn, value2));
+                    push(interpreter.copyOperation(insn, value1));
                     break;
                 }
             }
@@ -438,18 +438,18 @@ public class Frame<V extends Value> {
                         if (value4.getSize() == 1) {
                             push(interpreter.copyOperation(insn, value2));
                             push(interpreter.copyOperation(insn, value1));
-                            push(value4);
-                            push(value3);
-                            push(value2);
-                            push(value1);
+                            push(interpreter.copyOperation(insn, value4));
+                            push(interpreter.copyOperation(insn, value3));
+                            push(interpreter.copyOperation(insn, value2));
+                            push(interpreter.copyOperation(insn, value1));
                             break;
                         }
                     } else {
                         push(interpreter.copyOperation(insn, value2));
                         push(interpreter.copyOperation(insn, value1));
-                        push(value3);
-                        push(value2);
-                        push(value1);
+                        push(interpreter.copyOperation(insn, value3));
+                        push(interpreter.copyOperation(insn, value2));
+                        push(interpreter.copyOperation(insn, value1));
                         break;
                     }
                 }
@@ -459,15 +459,15 @@ public class Frame<V extends Value> {
                     value3 = pop();
                     if (value3.getSize() == 1) {
                         push(interpreter.copyOperation(insn, value1));
-                        push(value3);
-                        push(value2);
-                        push(value1);
+                        push(interpreter.copyOperation(insn, value3));
+                        push(interpreter.copyOperation(insn, value2));
+                        push(interpreter.copyOperation(insn, value1));
                         break;
                     }
                 } else {
                     push(interpreter.copyOperation(insn, value1));
-                    push(value2);
-                    push(value1);
+                    push(interpreter.copyOperation(insn, value2));
+                    push(interpreter.copyOperation(insn, value1));
                     break;
                 }
             }


### PR DESCRIPTION
Before this change, `Frame.execute` did not invoke the interpreter's
`copyInstruction` method for all values that are pushed on the frame's
when executing some copying instructions.

For example, in the case of SWAP, copyInstruction is invoked:

    value2 = pop();
    value1 = pop();
    push(interpreter.copyOperation(insn, value2));
    push(interpreter.copyOperation(insn, value1));

For DUP on the other hand, the original value is pushed onto the
stack without notifying the interpreter:

    value1 = pop();
    push(value1);
    push(interpreter.copyOperation(insn, value1));

This leads to a problem for the `SourceInterpreter`, which collects
for every value a set of potential producer instructions. Given the
bytecode sequence

    NEW java/lang/Object
    DUP
    INVOKESPECIAL java/lang/Object.<init> ()V

In the frame of the INVOKESPECIAL instruction, the value on the stack
lists as its producer the `NEW` operation instead of the `DUP`, which
not expected.