### PR TITLE
Fix findItemByIndex in case of hash collisions

### DIFF
--- a/src/main/java/scala/tools/asm/ClassWriter.java
+++ b/src/main/java/scala/tools/asm/ClassWriter.java
@@ -1747,12 +1747,20 @@ public class ClassWriter extends ClassVisitor {
     }
 
     /**
-     * Find item that whose index is `index`.
+     * Returns the item with a specific index.
+     *
+     * @param index
+     *            the index of the searched item.
+     * @return the item with the given index.
      */
     public Item findItemByIndex(int index) {
-        int i = 0;
-        while (i < items.length && (items[i] == null || items[i].index != index)) i++;
-        return items[i];
+        for (Item item : items) {
+            while (item != null) {
+                if (item.index == index) return item;
+                item = item.next;
+            }
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
The method `findItemByIndex` only looked at the first item in each
bucket of the `items` hash table.

Also, in case the item was not found, the counter `i` would be at
`items.length`, therefore the access `items[i]` crashed with an
ArrayIndexOutOfBoundsException.

Fixes the issue https://github.com/scala/scala-asm/issues/8.