### PR TITLE
Fill Exception message when maximum String literal length is exceeded

### DIFF
--- a/src/main/java/scala/tools/asm/ByteVector.java
+++ b/src/main/java/scala/tools/asm/ByteVector.java
@@ -210,7 +210,7 @@ public class ByteVector {
     public ByteVector putUTF8(final String s) {
         int charLength = s.length();
         if (charLength > 65535) {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("Maximum String literal length exceeded");
         }
         int len = length;
         if (len + 2 + charLength > data.length) {


### PR DESCRIPTION
Gatling compiles Scala classes on the fly with Zinc.
Be it a program bug or a user error, some Strings sometimes end up being longer than the maximum String length. It would be nice if we could get an Exception with the proper message.

I guess there's the same issue with maximum file size and maximum method size, will check.
