### PR TITLE
Support Java 9 bytecode format

### DIFF
--- a/src/main/java/scala/tools/asm/ClassReader.java
+++ b/src/main/java/scala/tools/asm/ClassReader.java
@@ -166,7 +166,7 @@ public class ClassReader {
     public ClassReader(final byte[] b, final int off, final int len) {
         this.b = b;
         // checks the class version
-        if (readShort(off + 6) > Opcodes.V1_8) {
+        if (readShort(off + 6) > Opcodes.V1_9) {
             throw new IllegalArgumentException();
         }
         // parses the constant pool

--- a/src/main/java/scala/tools/asm/Opcodes.java
+++ b/src/main/java/scala/tools/asm/Opcodes.java
@@ -58,6 +58,7 @@ public interface Opcodes {
     int V1_6 = 0 << 16 | 50;
     int V1_7 = 0 << 16 | 51;
     int V1_8 = 0 << 16 | 52;
+    int V1_9 = 0 << 16 | 53;
 
     // access flags
 


### PR DESCRIPTION
AFAIK the bytecode format was bumped to indicate that
code compiled with `-target 9` requires boostrap methods
that only exist in the Java 9 standard library for the
new String concatenation based on invokedynamic. So we
probably don't need changes to the bytecode parser/writers.