### PR TITLE
Support for Java 10 class file version 54.

### DIFF
--- a/src/main/java/scala/tools/asm/ClassReader.java
+++ b/src/main/java/scala/tools/asm/ClassReader.java
@@ -156,7 +156,7 @@ public class ClassReader {
     public ClassReader(final byte[] b, final int off, final int len) {
         this.b = b;
         // checks the class version
-        if (readShort(off + 6) > Opcodes.V9) {
+        if (readShort(off + 6) > Opcodes.V10) {
             throw new IllegalArgumentException();
         }
         // parses the constant pool

--- a/src/main/java/scala/tools/asm/Opcodes.java
+++ b/src/main/java/scala/tools/asm/Opcodes.java
@@ -59,7 +59,8 @@ public interface Opcodes {
     int V1_6 = 0 << 16 | 50;
     int V1_7 = 0 << 16 | 51;
     int V1_8 = 0 << 16 | 52;
-    int V9 = 0 << 16 | 53;
+    int V9   = 0 << 16 | 53;
+    int V10  = 0 << 16 | 54;
 
     // access flags
 

--- a/src/main/java/scala/tools/asm/util/ASMifier.java
+++ b/src/main/java/scala/tools/asm/util/ASMifier.java
@@ -223,6 +223,9 @@ public class ASMifier extends Printer {
         case Opcodes.V9:
             buf.append("V9");
             break;
+        case Opcodes.V10:
+            buf.append("V10");
+            break;
         default:
             buf.append(version);
             break;


### PR DESCRIPTION
From OW2 commit f8357974a1a958b0769d50d8d3307e450973ba4c.

It appears there are no changes to the classfile format in Java 10 other than the version bump to 54.

The OW2 project has switched to gradle and made major changes to the organisation of their repository. Upgrading scala-asm to version 6.1.1 looks like it would be a lot of work, so I thought I'd try submitting this PR to get Java 10 support.