### PR TITLE
[asm-cherry-pick] [move to start] Use JDK8 to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,7 @@ env:
 
 script: admin/build.sh
 
-# https://github.com/travis-ci/travis-ci/issues/8199#issuecomment-327246053
-addons:
-  apt:
-    packages:
-      - openjdk-6-jdk
-
-jdk: openjdk6
+jdk: openjdk8
 
 notifications:
   email: lukas.rytz@lightbend.com

--- a/build.sbt
+++ b/build.sbt
@@ -25,9 +25,9 @@ git.useGitDescribe := true
 scalaVersionsByJvm in ThisBuild := {
   val vs = List("2.11.11")
   Map(
-    6 -> vs.map(_ -> true),
+    6 -> vs.map(_ -> false),
     7 -> vs.map(_ -> false),
-    8 -> vs.map(_ -> false),
+    8 -> vs.map(_ -> true),
     9 -> vs.map(_ -> false))
 }
 
@@ -37,9 +37,9 @@ autoScalaLibrary := false
 // Don't add `_<scala-version>` to the jar file name - it's a Java-only project, no Scala cross-versioning needed
 crossPaths := false
 
-javacOptions ++= Seq("-g", "-source", "1.5", "-target", "1.6")
+javacOptions ++= Seq("-g", "-source", "1.6", "-target", "1.6")
 
 // javadoc fails if we pass all of the above
-javacOptions in doc := Seq("-source", "1.5")
+javacOptions in doc := Seq("-source", "1.6")
 
 OsgiKeys.exportPackage := Seq(s"scala.tools.asm.*;version=${version.value}")


### PR DESCRIPTION
Our Travis config no longer [seems to work](https://travis-ci.org/scala/scala-asm/builds/389051634) to install and switch to JDK6.

Rather than messing around with this, I propose we just build with Java 8. We are already using `-target 1.6`.

The risk is that we start using an API that only exists in Java 8, which cause a breakage under Scala 2.11.12 on Java 6/7.

We could mitigate that risk by include a manual step in our release process to compile locally with JDK6.